### PR TITLE
Introduce loss_functions.yaml; Use CompositionalMetrics

### DIFF
--- a/res/configs/loss_functions.yaml
+++ b/res/configs/loss_functions.yaml
@@ -1,0 +1,83 @@
+# Loss function relative percentages
+# Set to True if you want to use the scaling and correction as described in the paper.
+## Only affects l1, poisson, psnr, ssim, ms_ssim
+## Values can be found down below
+use_scaling: False
+l1: 0.0
+poisson: 0.0
+psnr: 0.5
+ssim: 0.0
+ms_ssim: 0.5
+vgg:
+  p: 0.0
+  vgg_model: vgg19
+  batch_norm: False
+  layers: 8
+
+# scaling and correction values as calculated for the paper
+# If you want to know the individual values used for the calculation of these scaling/correction values then check
+# https://github.com/SamSweere/xmm-superres-denoise/blob/7adc69bd1348bcd371a7063bdb31feaa697de7af/xmm_superres_denoise/utils/loss_functions.py#L15
+linear:
+  l1:
+    scaling: 27.404768429706774
+    correction: -0.5746779939709512
+  poisson:
+    scaling: 6.583278472679395
+    correction: -1.187623436471363
+  psnr:
+    scaling: -0.11938872970391594
+    correction: 3.6491165234001905
+  ssim:
+    scaling: -2.97441998810232
+    correction: 2.1469363474122547
+  ms_ssim:
+    scaling: -2.85143997718848
+    correction: 2.737382378100941
+sqrt:
+  l1:
+    scaling: 9.65623792970259
+    correction: -0.5189262263422172
+  poisson:
+    scaling: 12.269938650306754
+    correction: -5.137423312883438
+  psnr:
+    scaling: -0.121713729308666
+    correction: 2.7966163583252186
+  ssim:
+    scaling: -3.0684258975145746
+    correction: 1.417919607241485
+  ms_ssim:
+    scaling: -3.0165912518853695
+    correction: 2.636500754147813
+asinh:
+  l1:
+    scaling: 5.651952749675013
+    correction: -0.4542474424913807
+  poisson:
+    scaling: 0.4388467108439022
+    correction: -0.22920963707377018
+  psnr:
+    scaling: -0.11042402826855124
+    correction: 2.1554770318021204
+  ssim:
+    scaling: -3.2824552765468566
+    correction: 1.2020351222714591
+  ms_ssim:
+    scaling: -1.6189088554314395
+    correction: 1.3368949328152826
+log:
+  l1:
+    scaling: 4.071661237785016
+    correction: -0.4364820846905537
+  poisson:
+    scaling: 0.39835876190096803
+    correction: -0.2616021989403656
+  psnr:
+    scaling: -0.1108524553818867
+    correction: 1.8665336437202082
+  ssim:
+    scaling: -3.414600833162603
+    correction: 1.176671447107833
+  ms_ssim:
+    scaling: -2.043318348998774
+    correction: 1.6309767061708214

--- a/res/configs/model/esr_gen.yaml
+++ b/res/configs/model/esr_gen.yaml
@@ -6,15 +6,3 @@ residual_blocks: 4
 learning_rate: 0.0001
 b1: 0.9
 b2: 0.999
-# Loss function relative percentages
-loss:
-  l1: 0.0
-  poisson: 0.0
-  psnr: 0.5
-  ssim: 0.0
-  ms_ssim: 0.5
-  vgg:
-    p: 0.0
-    vgg_model: vgg19
-    batch_norm: False
-    layers: 8

--- a/res/configs/model/rrdb_denoise.yaml
+++ b/res/configs/model/rrdb_denoise.yaml
@@ -6,15 +6,3 @@ residual_blocks: 4
 learning_rate: 0.0001
 b1: 0.9
 b2: 0.999
-# Loss function relative percentages
-loss:
-  l1: 0.0
-  poisson: 0.0
-  psnr: 0.0
-  ssim: 1.0
-  ms_ssim: 0.0
-  vgg:
-    p: 0.0
-    vgg_model: vgg19
-    batch_norm: False
-    layers: 8

--- a/res/configs/model/swinir.yaml
+++ b/res/configs/model/swinir.yaml
@@ -21,15 +21,3 @@ depths:
 learning_rate: 0.0001
 b1: 0.9
 b2: 0.999
-# Loss function relative percentages
-loss:
-  l1: 1.0
-  poisson: 0.0
-  psnr: 0.0
-  ssim: 0.0
-  ms_ssim: 0.0
-  vgg:
-    p: 0.0
-    vgg_model: vgg19
-    batch_norm: False
-    layers: 8

--- a/xmm_superres_denoise/train.py
+++ b/xmm_superres_denoise/train.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
     )
     model_config["batch_size"] = dataset_config["batch_size"]
 
-    loss_config = model_config["loss"]
+    loss_config: dict = read_yaml(Path("res") / "configs" / "loss_functions.yaml")
 
     trainer_config: dict = run_config["trainer"]
 


### PR DESCRIPTION
Closes #12 
Loss functions can now be completely configured via `res/configs/loss_functions.yaml`.
This cleans up the code a bit and offers users a simpler way to manipulate calculations.
Furthermore now it is possible to avoid using the scaling and correction used in the paper. 
Makes things a bit more flexible (e.g. `SwinIR` is trained on `L1` for classical SR-task -> it's probably better to also use it in our case)

I know that IDEs will give a "Expected type `Metric` but got `float`" warning when scaling the metric but I've opened a [PR](https://github.com/Lightning-AI/torchmetrics/pull/1851) for that.